### PR TITLE
fixed main handler method, so default works

### DIFF
--- a/app/tasks/MainTask.php
+++ b/app/tasks/MainTask.php
@@ -2,7 +2,7 @@
 
 class MainTask extends \Phalcon\CLI\Task
 {
-    public function indexAction() {
+    public function mainAction(){
          echo "\nThis is the default task and the default action \n";
     }
 }


### PR DESCRIPTION
the indexAction is the default action for webapps but mainAction is the default action for cli apps, this way no arguments are needed to show the default output. 
